### PR TITLE
Create domain aggregates

### DIFF
--- a/aggregate/customer.go
+++ b/aggregate/customer.go
@@ -1,0 +1,38 @@
+// Package aggregate holds our aggregates that combines many entities into a full object
+package aggregate
+
+import (
+	"errors"
+	"github.com/google/uuid"
+	"github.com/shari4ov/ddd-go.git/entity"
+	"github.com/shari4ov/ddd-go.git/valueobject"
+)
+
+type Customer struct {
+	// Person is the root entity of customer
+	// which means person.ID is the main identifier for the customer
+	person       *entity.Person
+	products     []*entity.Item
+	transactions []valueobject.Transaction
+}
+
+var (
+	ErrInvalidPerson = errors.New("invalid customer name")
+)
+
+// NewCustomer is a factory to create a new customer aggregate
+// it will validate that the name is not empty
+func NewCustomer(name string) (Customer, error) {
+	if name == "" {
+		return Customer{}, ErrInvalidPerson
+	}
+	person := &entity.Person{
+		ID:   uuid.New(),
+		Name: name,
+	}
+	return Customer{
+		person:       person,
+		products:     make([]*entity.Item, 0),
+		transactions: make([]valueobject.Transaction, 0),
+	}, nil
+}

--- a/aggregate/customer_test.go
+++ b/aggregate/customer_test.go
@@ -1,0 +1,35 @@
+package aggregate_test
+
+import (
+	"errors"
+	"github.com/shari4ov/ddd-go.git/aggregate"
+	"testing"
+)
+
+func TestCustomer_NewCustomer(t *testing.T) {
+	type testCase struct {
+		test          string
+		name          string
+		expectedError error
+	}
+	testCases := []testCase{
+		{
+			test:          "Empty name validation",
+			name:          "",
+			expectedError: aggregate.ErrInvalidPerson,
+		},
+		{
+			test:          "Valid name",
+			name:          "Kenan",
+			expectedError: nil,
+		},
+	}
+	for _, v := range testCases {
+		t.Run(v.test, func(t *testing.T) {
+			_, err := aggregate.NewCustomer(v.name)
+			if !errors.Is(err, v.expectedError) {
+				t.Errorf("expected error %v, got %v", v.expectedError, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
- Created `customer` aggregates that combine person, person's products, and transactions. The aim of customer aggregate is to mix business logic with invariants. 
- Created `NewCustomer` factory method returns customer object.
- Created a `customer` aggregate test to test two states of the `NewCustomer` factory method: with a valid person name and an invalid person name. 